### PR TITLE
Fix IsTrimmable property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# JetBrains Rider
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2024-02-05
+
+### Changed
+
+- Fixes `IsTrimmable` property on the project.
+
 ## [1.1.1] - 2023-11-15
 
 ### Added

--- a/src/Microsoft.Kiota.Serialization.Multipart.csproj
+++ b/src/Microsoft.Kiota.Serialization.Multipart.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.1.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Microsoft.Kiota.Serialization.Multipart.csproj
+++ b/src/Microsoft.Kiota.Serialization.Multipart.csproj
@@ -34,7 +34,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <NoWarn>$(NoWarn);NU5048;NETSDK1138</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFrameworkVersion)' == 'net5.0'">  
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">  
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/src/Microsoft.Kiota.Serialization.Multipart.csproj
+++ b/src/Microsoft.Kiota.Serialization.Multipart.csproj
@@ -40,7 +40,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.8" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.9" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/MultipartSerializationWriter.cs
+++ b/src/MultipartSerializationWriter.cs
@@ -88,7 +88,7 @@ public class MultipartSerializationWriter : ISerializationWriter
     public void WriteDoubleValue(string? key, double? value) => throw new NotImplementedException();
     /// <inheritdoc/>
 #if NET5_0_OR_GREATER
-    public void WriteEnumValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]T>(string? key, T? value) where T : struct, Enum => throw new NotImplementedException();
+    public void WriteEnumValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]T>(string? key, T? value) where T : struct, Enum => throw new NotImplementedException();
 #else
     public void WriteEnumValue<T>(string? key, T? value) where T : struct, Enum => throw new NotImplementedException();
 #endif

--- a/src/MultipartSerializationWriter.cs
+++ b/src/MultipartSerializationWriter.cs
@@ -70,7 +70,7 @@ public class MultipartSerializationWriter : ISerializationWriter
     public void WriteByteValue(string? key, byte? value) => throw new NotImplementedException();
     /// <inheritdoc/>
 #if NET5_0_OR_GREATER
-    public void WriteCollectionOfEnumValues<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]T>(string? key, IEnumerable<T?>? values) where T : struct, Enum => throw new NotImplementedException();
+    public void WriteCollectionOfEnumValues<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(string? key, IEnumerable<T?>? values) where T : struct, Enum => throw new NotImplementedException();
 #else
     public void WriteCollectionOfEnumValues<T>(string? key, IEnumerable<T?>? values) where T : struct, Enum => throw new NotImplementedException();
 #endif
@@ -88,7 +88,7 @@ public class MultipartSerializationWriter : ISerializationWriter
     public void WriteDoubleValue(string? key, double? value) => throw new NotImplementedException();
     /// <inheritdoc/>
 #if NET5_0_OR_GREATER
-    public void WriteEnumValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)]T>(string? key, T? value) where T : struct, Enum => throw new NotImplementedException();
+    public void WriteEnumValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(string? key, T? value) where T : struct, Enum => throw new NotImplementedException();
 #else
     public void WriteEnumValue<T>(string? key, T? value) where T : struct, Enum => throw new NotImplementedException();
 #endif


### PR DESCRIPTION
This PR fixes the condition gating the `IsTrimmable` property in the .csproj, and any new build errors that this causes.

This is related to: https://github.com/microsoft/kiota-abstractions-dotnet/issues/188